### PR TITLE
Fix no matches

### DIFF
--- a/KeychainTool/KeychainTool.entitlements
+++ b/KeychainTool/KeychainTool.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>*</string>
+		<string>com.apple.hap.pairing</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Nowadays such wildcard entitlements don't work anymore. There's a limit to how many entitlements can be applied. On iOS the magic number appears to be 36, and '*' matches more then that. My assumption is that MacOS is the same.